### PR TITLE
Prevent git from indexing PhpStorm metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 config.json
+.idea/*


### PR DESCRIPTION
We don't need to have the PhpStorm metadata in the repository